### PR TITLE
Fix city resolution and test coverage

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,6 +1,6 @@
 FROM ubuntu:14.04
 
-MAINTAINER Casey Hilland <chilland@caerusassociates.com>
+MAINTAINER Andy Halterman <ahalterman0@gmail.com>
 
 RUN echo "deb http://archive.ubuntu.com/ubuntu/ $(lsb_release -sc) main universe" >> /etc/apt/sources.list
 
@@ -26,7 +26,7 @@ RUN tar --no-same-owner -xjf MITIE-models-v0.2.tar.bz2
 RUN mkdir /home/ubuntu/MITIE/mitielib/build
 RUN cd mitielib/build; cmake ..
 RUN cd mitielib/build; cmake --build . --config Release --target install
-RUN pip install git+https://github.com/caerusassociates/mitie-py.git
+RUN pip install git+https://github.com/openeventdata/mitie-py.git
 
 EXPOSE 5000
 

--- a/README.md
+++ b/README.md
@@ -3,10 +3,14 @@
 mordecai
 =========
 
-Custom-built full text geocoding. This software was donated to the Open Event
-Data Alliance by Caerus Associates.
+Custom-built full text geocoding. 
 
-The purpose of mordecai is to accept text and return structured geographic information in return. It does this in several ways:
+This software was donated to the Open Event Data Alliance by Caerus Associates.
+See [Releases](https://github.com/openeventdata/mordecai/releases) for the
+2015-2016 production version of Mordecai.
+
+`Mordecai` accepts text and returns structured geographic information extracted
+from it. It does this in several ways:
 
 - It uses [MITIE](https://github.com/mit-nlp/MITIE) to extract placenames from
   the text. In the default configuration, it uses the out-of-the-box MITIE
@@ -40,9 +44,9 @@ specifically RAM, so it should be noted that running this on a small computer
 will be met with suboptimal performance. Our production deployment has the
 Geonames gazetter in an Elasticsearch cluster with a few nodes.
 
-**Please note that many of the required components for mordecai, such as the
+Please note that many of the required components for mordecai, such as the
 word2vec and MITIE models, are rather large so downloading and loading takes
-a while.**
+a while.
 
 Requirements
 ------------
@@ -115,7 +119,7 @@ Mordecai is meant to be easy to customize. There are a few ways to do this.
 Tests
 -----
 
-`mordecai` currently includes a few basic unit tests. To run the tests:
+`mordecai` currently includes a few unit tests. To run the tests:
 
 ```
 cd resources

--- a/config.ini
+++ b/config.ini
@@ -3,5 +3,7 @@ mitie_directory = /home/ubuntu/MITIE/mitielib
 mitie_ner_model = /home/ubuntu/MITIE/MITIE-models/english/ner_model.dat
 word2vec_model = /home/ubuntu/GoogleNews-vectors-negative300.bin.gz
 
-#[Server]
-#geonames = 54.152.85.116
+[Server]
+geonames_host = localhost
+geonames_port = 9200
+

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -5,4 +5,4 @@ mordecai:
     ports:
         - "5000:5000"
 elastic:
-    image: caerusassociates/es-geonames
+    image: openeventdata/es-geonames

--- a/resources/places.py
+++ b/resources/places.py
@@ -195,13 +195,11 @@ class PlacesAPI(Resource):
             except ValueError:
                 return json.dumps(locations)
 
-        out = utilities.mitie_context(text, ner_model)
-
-        located = self.process(out, country_filter)
-
+        located = self.process(text, country_filter)
         return located
 
-    def process(self, locs, country_filter):
+    def process(self, text, country_filter):
+        locs = utilities.mitie_context(text, ner_model)
         locations = []
         for i in locs['entities']:
             if i['text'] in country_names:
@@ -219,10 +217,9 @@ class PlacesAPI(Resource):
                     try:
                         t = self.place_cache[cache_term]
                     except KeyError:
-                        t = utilities.query_geonames_featureclass(es_conn,
-                                                                  searchterm,
-                                                                  country_filter,
-                                                                  feature_class)
+                        t = utilities.query_geonames(es_conn,
+                                                     searchterm,
+                                                     country_filter)
                         self.place_cache[cache_term] = t
                     loc = pick_best_result2(t, i['text'], i['context'])
                     # loc is a nice format for debugging and looks like

--- a/resources/tests/test_mordecai.py
+++ b/resources/tests/test_mordecai.py
@@ -1,7 +1,11 @@
 import os
+import sys
+import glob
+from ConfigParser import ConfigParser
+from mitie import named_entity_extractor
 from ..country import CountryAPI
 from ..places import PlacesAPI
-
+from ..utilities import mitie_context, setup_es, query_geonames
 
 def test_places_api_one():
     if os.environ.get('CI'):
@@ -9,15 +13,46 @@ def test_places_api_one():
         assert ci == 'circle'
     else:
         a = PlacesAPI()
-        locs = {u'entities': [{u'context': ['meeting', 'happened', 'in', '.'],
-                            u'score': 1.3923831181343844, u'tag': u'LOCATION',
-                            u'text': 'Ontario'}]}
-
-        result = a.process(locs, 'CAN')
-        gold = [{u'countrycode': u'CAN', u'lat': 43.65004, u'lon': -79.90554,
-                u'placename': u'SunnyView Dental', u'searchterm': 'Ontario'}]
+        locs = "Ontario"
+        result = a.process(locs, ['CAN'])
+        gold = [{u'lat': 49.25014, u'searchterm': 'Ontario', u'lon': -84.49983, u'countrycode': u'CAN', u'placename': u'Ontario'}]
         assert result == gold
 
+def test_query_geonames():
+    conn = setup_es()
+    placename = "Berlin"
+    country_filter = ["DEU"]
+    qg = query_geonames(conn, placename, country_filter)
+    hit_hit_name = qg['hits']['hits'][0]['name'] 
+    assert hit_hit_name == "Berlin"
+
+def test_places_api_syria():
+    if os.environ.get('CI'):
+        ci = 'circle'
+        assert ci == 'circle'
+    else:
+        a = PlacesAPI()
+        locs = "Rebels from Aleppo attacked Damascus."
+        result = a.process(locs, ['SYR'])
+        gold = [{u'lat': 36.20124, u'searchterm': 'Aleppo', u'lon': 37.16117, u'countrycode': u'SYR', u'placename': u'Aleppo'}, 
+                {u'lat': 33.5102, u'searchterm': 'Damascus', u'lon': 36.29128, u'countrycode': u'SYR', u'placename': u'Damascus'}]
+        assert result == gold
+
+
+def test_mitie_context():
+    __location__ = os.path.realpath(os.path.join(os.getcwd(),
+                                                 os.path.dirname(__file__)))
+    config_file = glob.glob(os.path.join(__location__, '../../config.ini'))
+    parser = ConfigParser()
+    parser.read(config_file)
+    mitie_directory = parser.get('Locations', 'mitie_directory')
+    mitie_ner_model = parser.get('Locations', 'mitie_ner_model')
+    sys.path.append(mitie_directory)
+    ner_model = named_entity_extractor(mitie_ner_model)
+    text = "The meeting happened in Ontario."
+    mc = mitie_context(text, ner_model)
+    mc_gold = {u'entities': [{u'text': 'Ontario', u'tag': u'LOCATION', u'score': 1.3923831181343844, u'context': ['meeting', 'happened', 'in', '.']}]}
+    assert mc == mc_gold
 
 def test_country_process_one():
     a = CountryAPI()
@@ -29,3 +64,23 @@ def test_country_process_two():
     a = CountryAPI()
     result = a.process('Rebels from Damascus attacked Aleppo')
     assert result == u'SYR'
+
+def test_city_resolution():
+    a = PlacesAPI()
+    city_list = [("Lagos", "NGA"),
+             ("Mogadishu", "SOM"),
+             ("Mannheim", "DEU"),
+             ("Noida", "IND"),
+             ("Berlin", "DEU"),
+             ("Damascus", "SYR"),
+             ("New York", "USA"),
+             ("San Francisco", "USA"),
+             ("Freetown", "SLE"),
+             ("Cape Town", "ZAF"),
+             ("Windhoek", "NAM"),
+             ("Paris", "FRA")]
+    rs = [a.process(c[0], [c[1]]) for c in city_list]
+    searched_cities = [c[0]['searchterm'] for c in rs]
+    resolved_cities = [c[0]['placename'] for c in rs]
+    assert resolved_cities == searched_cities
+   

--- a/resources/utilities.py
+++ b/resources/utilities.py
@@ -22,18 +22,15 @@ mitie_ner_model = parser.get('Locations', 'mitie_ner_model')
 def setup_mitie():
     sys.path.append(mitie_directory)
     ner_model = named_entity_extractor(mitie_ner_model)
-
     return ner_model
 
 
 def setup_es():
     try:
-        if 'Server' in parser.sections():
-            es_ip = parser.get('Server', 'geonames')
-        else:
-            es_ip = os.environ['ELASTIC_PORT_9200_TCP_ADDR']
+        es_ip = parser.get('Server', 'geonames_host')
+        es_port = parser.get('Server', 'geonames_port')
 
-        es_url = 'http://{}:{}/'.format(es_ip, '9200')
+        es_url = 'http://{}:{}/'.format(es_ip, es_port)
         CLIENT = Elasticsearch(es_url)
         S = Search(CLIENT)
 


### PR DESCRIPTION
This PR is focused on fixing a bug in city name resolution (#1) with some associated other improvements: 

- Resolve #1, which deals with cities being resolved to places inside the city, rather than the city itself. This was the result of trying to narrowing the Elasticsearch query using keywords from the vicinity of the place name. Just doing a regular query gives much better results. Future work can figure out if it makes sense to add back in `query_geonames_featureclass`.
- Move the MITIE entity extraction of `/places` from the `post` function to the `process` function, which makes more sense and makes it easier to test.
- Greatly expand test coverage to include MITIE, `query_geonames`, and whether cities are correctly resolved.
- Make a small change to `config` to allow a custom Elasticsearch port.