### PR TITLE
Improve speed with batch_geoparse

### DIFF
--- a/README.md
+++ b/README.md
@@ -51,6 +51,12 @@ Mordecai is on PyPI and can be installed for Python3 with pip:
 pip install mordecai
 ```
 
+You can then download the required spaCy NLP model:
+
+```
+python -m spacy download en_core_web_lg
+```
+
 In order to work, Mordecai needs access to a Geonames gazetteer running in
 Elasticsearch. The easiest way to set it up is by running the following
 commands (you must have [Docker](https://docs.docker.com/engine/installation/)
@@ -103,6 +109,8 @@ When instantiating the `Geoparser()` module, the following options can be change
     wrong and will return weird results. Defaults to `0.6`. 
 - `verbose` : Return all the features used in the country picking model?
     Defaults to `False`. 
+- `n_threads`: used in the `batch_geoparse` method to set the number of threads
+    to run spaCy's `nlp.pipe` process and `geoparse` as a whole.
 
 `.geoparse` is the primary endpoint and the only one that most users will need.
 Other methods are primarily internal to Mordecai but may be directly useful in
@@ -114,6 +122,10 @@ some cases:
     search over Geonames in Elasticsearch
 - methods with the `_feature` prefix are internal methods for
     calculating country picking features from text.
+
+`batch_geoparse` is an experimental endpoint that takes in a list of documents,
+batch processes them, and returns a corresponding list of lists. It currently
+around twice as fast as `geoparse`.
 
 Tests
 -----

--- a/mordecai/geoparse.py
+++ b/mordecai/geoparse.py
@@ -19,7 +19,7 @@ except NameError:
 
 class Geoparser:
     def __init__(self, es_ip="localhost", es_port="9200", verbose = False,
-                country_threshold = 0.6):
+                country_threshold = 0.6, num_threads = 2):
         DATA_PATH = pkg_resources.resource_filename('mordecai', 'data/')
         MODELS_PATH = pkg_resources.resource_filename('mordecai', 'models/')
         self._cts = utilities.country_list_maker()
@@ -41,6 +41,7 @@ class Geoparser:
         feature_codes = pd.read_csv(DATA_PATH + "feature_codes.txt", sep="\t", header = None)
         self._code_to_text = dict(zip(feature_codes[1], feature_codes[3])) # human readable geonames IDs
         self.verbose = verbose # return the full dictionary or just the good parts?
+        self.num_threads = num_threads
         try:
             # https://www.reddit.com/r/Python/comments/3a2erd/exception_catch_not_catching_everything/
             #with nostderr():
@@ -969,4 +970,7 @@ class Geoparser:
 
         return proced
 
-
+    def batch_geoparse(self, text_list):
+        nlped_docs = nlp.pipe(text_list, n_threads = self.num_threads)
+        processed = [self.geoparse(doc) for doc in nlped_docs]
+        return processed

--- a/mordecai/geoparse.py
+++ b/mordecai/geoparse.py
@@ -952,6 +952,9 @@ class Geoparser:
                 continue
             # Pick the best place
             X, meta = self.features_for_rank(loc, res)
+            if X.shape[1] == 0:
+                # This happens if there are no results...
+                continue
             all_tasks, sorted_meta, sorted_X = self.format_for_prodigy(X, meta, loc['word'], return_feature_subset=True)
             fl_pad = np.pad(sorted_X, ((0, 4 - sorted_X.shape[0]), (0, 0)), 'constant')
             fl_unwrap = fl_pad.flatten()

--- a/mordecai/geoparse.py
+++ b/mordecai/geoparse.py
@@ -970,6 +970,22 @@ class Geoparser:
         return proced
 
     def batch_geoparse(self, text_list):
+        """
+        Batch geoparsing function. Take in a list of text documents and return a list of lists
+        of the geoparsed documents. The speed improvements come from using spaCy's `nlp.pipe` and by multithreading
+        calls to `geoparse`.
+
+        Parameters
+        ----------
+        text_list : list of strs
+            List of documents. The documents should not have been pre-processed by spaCy.
+
+        Returns
+        -------
+        proced : list of list of dicts
+            The list is the same length as the input list of documents. Each element is a list of geolocated entities.
+        """
+
         nlped_docs = nlp.pipe(text_list, n_threads = self.n_threads)
         pool = ThreadPool(self.n_threads)
         processed = pool.map(self.geoparse, nlped_docs)

--- a/mordecai/tests/test_mordecai.py
+++ b/mordecai/tests/test_mordecai.py
@@ -116,3 +116,15 @@ def test_issue_40(geo):
     locs = geo.geoparse(doc)
     assert len(locs) > 2
 
+def test_issue_40(geo):
+    doc_list = ["Government forces attacked the cities in Aleppo Governorate, while rebel leaders met in Geneva.",
+                "EULEX is based in Prishtina, Kosovo.",
+                "Clientelism may depend on brokers."]
+    locs = geo.batch_geoparse(doc_list)
+    assert len(locs) == 3
+    assert locs[0][0]['geo']['geonameid'] == '170063'
+    assert locs[0][1]['country_predicted'] == 'CHE'
+    assert locs[1][0]['geo']['feature_code'] == 'PPLC'
+    assert locs[1][1]['geo']['country_code3'] == 'XKX'
+    assert locs[2] == []
+

--- a/mordecai/tests/test_mordecai.py
+++ b/mordecai/tests/test_mordecai.py
@@ -110,3 +110,9 @@ def test_aleppo_geneva(geo):
     locs = geo.geoparse("Government forces attacked the cities in Aleppo Governorate, while rebel leaders met in Geneva.")
     assert locs[0]['geo']['country_code3'] == 'SYR'
     assert locs[1]['geo']['country_code3'] == 'CHE'
+
+def test_issue_40(geo):
+    doc = "In early 1938, the Prime Minister cut grants-in-aid to the provinces, effectively killing the relief project scheme. Premier Thomas Dufferin Pattullo closed the projects in April, claiming that British Columbia could not shoulder the burden alone. Unemployed men again flocked to Vancouver to protest government insensitivity and intransigence to their plight. The RCPU organized demonstrations and tin-canning (organized begging) in the city. Under the guidance of twenty-six-year-old Steve Brodie, the leader of the Youth Division who had cut his activist teeth during the 1935 relief camp strike, protesters occupied Hotel Georgia, the Vancouver Art Gallery (then located at 1145 West Georgia Street), and the main post office (now the Sinclair Centre)."
+    locs = geo.geoparse(doc)
+    assert len(locs) > 2
+


### PR DESCRIPTION
Improve the speed of Mordecai around 2x (see #30 for discussion)

Added a `batch_geoparse` method. The speed improvements here consist of:

- using spaCy's `nlp.pipe`, which is more efficient than repeated `nlp` calls and also runs mulithreaded without the GIL.
- making multithreaded calls to `geoparse`. The biggest bottleneck is waiting for ES, which isn't GIL locked, so we get good speed improvements.

Also, for both `geoparse` and `batch_geoparse`:

- Increase the size of the `query_geonames` caches from 200 to 1000. Around 50% of Mordecai's time is spent on ES calls. This led to a modest 7% speed increase in my tests, but it's basically free

This PR also include a fix to an error in the ranker function.