### PR TITLE
Catch Python 2 error on lru_cache

### DIFF
--- a/README.md
+++ b/README.md
@@ -38,14 +38,14 @@ Example usage
   'word': 'Ottawa'}]
 ```
 
-`mordecai` requires a running Elasticsearch service with Geonames in it. See
+Mordecai requires a running Elasticsearch service with Geonames in it. See
 "Installation" below for instructions.
 
 
 Installation and Requirements
 --------------------
 
-Mordecai is on PyPI and can be installed for Python3 with pip:
+Mordecai is on PyPI and can be installed for Python 3 with pip:
 
 ```
 pip install mordecai

--- a/mordecai/geoparse.py
+++ b/mordecai/geoparse.py
@@ -4,13 +4,16 @@ from elasticsearch_dsl.query import MultiMatch
 from elasticsearch_dsl import Search, Q
 import numpy as np
 from collections import Counter
-from functools import lru_cache
 import editdistance
 import pkg_resources
 import spacy
 from . import utilities
 from multiprocessing.pool import ThreadPool
-
+try:
+    from functools import lru_cache
+except ImportError:
+    from backports.functools_lru_cache import lru_cache
+    print("Mordecai requires Python 3 and seems to be running in Python 2.")
 
 try:
     nlp


### PR DESCRIPTION
Running Mordecai with Python2 leds to an error on trying to import `lru_cache`. It now catches and attempts to import the Python 2 version, but also recommends using Python 3, which is definitely the preferred way to use Mordecai.