### PR TITLE
Speed improvement and span fix

### DIFF
--- a/README.md
+++ b/README.md
@@ -128,8 +128,8 @@ When instantiating the `Geoparser()` module, the following options can be change
     wrong and will return weird results. Defaults to `0.6`. 
 - `verbose` : Return all the features used in the country picking model?
     Defaults to `False`. 
-- `n_threads`: used in the `batch_geoparse` method to set the number of threads
-    to run spaCy's `nlp.pipe` process and `geoparse` as a whole.
+- `threads`: whether to use threads to make parallel queries to the
+    Elasticsearch database. Defaults to `True`, which gives a ~6x speedup.
 
 `geoparse` is the primary endpoint and the only one that most users will need.
 Other methods are primarily internal to Mordecai but may be directly useful in
@@ -142,9 +142,8 @@ some cases:
 - methods with the `_feature` prefix are internal methods for
     calculating country picking features from text.
 
-`batch_geoparse` is an experimental endpoint that takes in a list of documents,
-batch processes them, and returns a corresponding list of lists. It currently
-around twice as fast as `geoparse`.
+`batch_geoparse` takes in a list of documents and uses spaCy's `nlp.pipe`
+method to process them more efficiently in the NLP step. 
 
 Advanced users on large machines can modify the `lru_cache` parameter from 250
 to 1000. This will use more memory but will increase parsing speed.
@@ -152,7 +151,7 @@ to 1000. This will use more memory but will increase parsing speed.
 Tests
 -----
 
-Mordecai includes a few unit tests. To run the tests, `cd` into the
+Mordecai includes unit tests. To run the tests, `cd` into the
 `mordecai` directory and run:
 
 ```

--- a/mordecai/geoparse.py
+++ b/mordecai/geoparse.py
@@ -10,6 +10,7 @@ from multiprocessing.pool import ThreadPool
 from elasticsearch.exceptions import ConnectionTimeout, ConnectionError
 import multiprocessing
 from tqdm import tqdm
+import warnings
 
 try:
     from functools import lru_cache
@@ -30,8 +31,8 @@ Install with this command: `python -m spacy download en_core_web_lg`.""")
 
 class Geoparser:
     def __init__(self, es_ip="localhost", es_port="9200", verbose=False,
-                 country_threshold=0.6, threads=False, progress=True,
-                 mod_date="2018-06-05"):
+                 country_threshold=0.6, threads=True, progress=True,
+                 mod_date="2018-06-05", **kwargs):
         DATA_PATH = pkg_resources.resource_filename('mordecai', 'data/')
         MODELS_PATH = pkg_resources.resource_filename('mordecai', 'models/')
         self._cts = utilities.country_list_maker()
@@ -55,6 +56,8 @@ class Geoparser:
         self.verbose = verbose  # return the full dictionary or just the good parts?
         self.progress = progress  # display progress bars?
         self.threads = threads
+        if 'n_threads' in kwargs.keys():
+            warnings.warn("n_threads is deprecated. Use threads=True instead.", DeprecationWarning)
         try:
             # https://www.reddit.com/r/Python/comments/3a2erd/exception_catch_not_catching_everything/
             # with nostderr():

--- a/mordecai/geoparse.py
+++ b/mordecai/geoparse.py
@@ -1,6 +1,5 @@
 import keras
 import pandas as pd
-from elasticsearch_dsl import Q
 import numpy as np
 from collections import Counter
 import editdistance
@@ -25,13 +24,14 @@ except NameError:
         nlp = spacy.load('en_core_web_lg', disable=['parser', 'tagger'])
         #nlp = spacy.load('en_core_web_lg', disable=['tagger'])
     except OSError:
-        print("ERROR: No spaCy NLP model installed. Install with this command: `python -m spacy download en_core_web_lg`.")
+        print("""ERROR: No spaCy NLP model installed.
+Install with this command: `python -m spacy download en_core_web_lg`.""")
 
 
 class Geoparser:
-    def __init__(self, es_ip="localhost", es_port="9200", verbose = False,
-                country_threshold = 0.6, threads = False, progress = True,
-                 mod_date = "2018-06-05"):
+    def __init__(self, es_ip="localhost", es_port="9200", verbose=False,
+                 country_threshold=0.6, threads=False, progress=True,
+                 mod_date="2018-06-05"):
         DATA_PATH = pkg_resources.resource_filename('mordecai', 'data/')
         MODELS_PATH = pkg_resources.resource_filename('mordecai', 'models/')
         self._cts = utilities.country_list_maker()
@@ -47,26 +47,30 @@ class Geoparser:
         self.country_model = keras.models.load_model(MODELS_PATH + "country_model.h5")
         self.rank_model = keras.models.load_model(MODELS_PATH + "rank_model.h5")
         self._skip_list = utilities.make_skip_list(self._cts)
-        self.training_setting = False # make this true if you want training formatted
+        self.training_setting = False  # make this true if you want training formatted
         # if the best country guess is below the country threshold, don't return anything at all
         self.country_threshold = country_threshold
-        feature_codes = pd.read_csv(DATA_PATH + "feature_codes.txt", sep="\t", header = None)
-        self._code_to_text = dict(zip(feature_codes[1], feature_codes[3])) # human readable geonames IDs
-        self.verbose = verbose # return the full dictionary or just the good parts?
-        self.progress = progress # display progress bars?
+        feature_codes = pd.read_csv(DATA_PATH + "feature_codes.txt", sep="\t", header=None)
+        self._code_to_text = dict(zip(feature_codes[1], feature_codes[3]))  # human readable geonames IDs
+        self.verbose = verbose  # return the full dictionary or just the good parts?
+        self.progress = progress  # display progress bars?
         self.threads = threads
         try:
             # https://www.reddit.com/r/Python/comments/3a2erd/exception_catch_not_catching_everything/
-            #with nostderr():
+            # with nostderr():
             self.conn.count()
         except:
-            raise ConnectionError("Could not establish contact with Elasticsearch at {0} on port {1}. Are you sure it's running? \n".format(es_ip, es_port),
-                 "Mordecai needs access to the Geonames/Elasticsearch gazetteer to function.",
-                 "See https://github.com/openeventdata/mordecai#installation-and-requirements",
-                 "for instructions on setting up Geonames/Elasticsearch")
+            raise ConnectionError("""Could not establish contact with Elasticsearch at {0} on port {1}.
+Are you sure it's running?
+Mordecai needs access to the Geonames/Elasticsearch gazetteer to function.
+See https://github.com/openeventdata/mordecai#installation-and-requirements
+for instructions on setting up Geonames/Elasticsearch""".format(es_ip, es_port))
         es_date = utilities.check_geonames_date(self.conn)
         if es_date != mod_date:
-            print("You may be using an outdated Geonames index. Your index is from {0}, while the most recent is {1}. Please see https://github.com/openeventdata/mordecai/ for instructions on updating.".format(es_date, mod_date))
+            print("""You may be using an outdated Geonames index.
+Your index is from {0}, while the most recent is {1}. Please see
+https://github.com/openeventdata/mordecai/ for instructions on updating.""".format(es_date, mod_date))
+
 
     def _feature_country_mentions(self, doc):
         """
@@ -82,7 +86,6 @@ class Geoparser:
         countries: dict
             the top two countries (ISO code) and their frequency of mentions.
         """
-
         c_list = []
         for i in doc.ents:
             try:
@@ -90,7 +93,6 @@ class Geoparser:
                 c_list.append(country)
             except KeyError:
                 pass
-
         count = Counter(c_list).most_common()
         try:
             top, top_count = count[0]
@@ -136,12 +138,13 @@ class Geoparser:
 
         keep_positions = np.asarray(keep_positions)
         try:
-            new_ent = ent.doc[keep_positions.min():keep_positions.max()+1]
+            new_ent = ent.doc[keep_positions.min():keep_positions.max() + 1]
             # can't set directly
             #new_ent.label_.__set__(ent.label_)
         except ValueError:
             new_ent = ent
         return new_ent
+
 
     def _feature_most_common(self, results):
         """
@@ -167,7 +170,7 @@ class Geoparser:
             return ""
 
 
-    def _feature_most_alternative(self, results, full_results = False):
+    def _feature_most_alternative(self, results, full_results=False):
         """
         Find the placename with the most alternative names and return its country.
         More alternative names are a rough measure of importance.
@@ -186,7 +189,7 @@ class Geoparser:
         try:
             alt_names = [len(i['alternativenames']) for i in results['hits']['hits']]
             most_alt = results['hits']['hits'][np.array(alt_names).argmax()]
-            if full_results == True:
+            if full_results:
                 return most_alt
             else:
                 return most_alt['country_code3']
@@ -243,7 +246,6 @@ class Geoparser:
                 "confid_b" : 0,
                 "country_2" : ""}
         ranks = simils.argsort()[::-1]
-        best_index = ranks[0]
         confid = simils.max()
         confid2 = simils[ranks[0]] - simils[ranks[1]]
         if confid == 0 or confid2 == 0:
@@ -254,6 +256,7 @@ class Geoparser:
                 "confid_b" : confid2,
                 "country_2" : self._cts[str(self._ct_nlp[ranks[1]])]}
         return country_picking
+
 
     def _feature_first_back(self, results):
         """
@@ -278,9 +281,9 @@ class Geoparser:
             second_back = results['hits']['hits'][1]['country_code3']
         except (TypeError, IndexError):
             second_back = ""
-
         top = (first_back, second_back)
         return top
+
 
     def is_country(self, text):
         """Check if a piece of text is in the list of countries"""
@@ -289,6 +292,7 @@ class Geoparser:
             return True
         else:
             return False
+
 
     @lru_cache(maxsize=250)
     def query_geonames(self, placename):
@@ -326,11 +330,13 @@ class Geoparser:
                 q = {"multi_match": {"query": placename,
                                      "fields": ['name', 'asciiname', 'alternativenames'],
                                          "fuzziness" : 1,
-                                         "operator":   "and"},
-                        }
+                                         "operator":   "and"
+                                     }
+                    }
                 res = self.conn.query(q)[0:50].execute()
         es_result = utilities.structure_results(res)
         return es_result
+
 
     @lru_cache(maxsize=250)
     def query_geonames_country(self, placename, country):
@@ -340,32 +346,30 @@ class Geoparser:
         # first, try for an exact phrase match
         q = {"multi_match": {"query": placename,
                              "fields": ['name^5', 'asciiname^5', 'alternativenames'],
-                            "type" : "phrase"}}
-        #r = Q("match", country_code3=country)
+                            "type": "phrase"}}
         res = self.conn.filter("term", country_code3=country).query(q)[0:50].execute()
 
         # if no results, use some fuzziness, but still require all terms to be present.
         # Fuzzy is not allowed in "phrase" searches.
         if res.hits.total == 0:
-                # tried wrapping this in a {"constant_score" : {"query": ... but made it worse
+            # tried wrapping this in a {"constant_score" : {"query": ... but made it worse
             q = {"multi_match": {"query": placename,
                                  "fields": ['name', 'asciiname', 'alternativenames'],
-                                     "fuzziness" : 1,
-                                     "operator":   "and"},
-                }
-            #r = Q("match", country_code3=country)
-            #res = self.conn.query(q).query(r)[0:50].execute()
+                                     "fuzziness": 1,
+                                     "operator":   "and"}}
             res = self.conn.filter("term", country_code3=country).query(q)[0:50].execute()
         out = utilities.structure_results(res)
         return out
 
 
+    # The following three lookup functions are used for the threaded queries.
     def proc_lookup(self, loc):
         try:
-           loc = self.query_geonames(loc['word'])
+            loc = self.query_geonames(loc['word'])
         except ConnectionTimeout:
-           loc = ""
+            loc = ""
         return loc
+
 
     def proc_lookup_country(self, loc):
         if loc['country_conf'] >= self.country_threshold:
@@ -374,11 +378,12 @@ class Geoparser:
         else:
             return ""
 
+
     def simple_lookup(self, word):
         try:
-           loc = self.query_geonames(word)
+            loc = self.query_geonames(word)
         except ConnectionTimeout:
-           loc = ""
+            loc = ""
         return loc
 
 
@@ -409,13 +414,14 @@ class Geoparser:
         AIRPORT_list = ["airport"]
         TERRAIN_list = ["mountain", "mountains", "stream", "river"]
         FOREST_list = ["forest"]
-
+        # TODO: incorporate positions, especially now that we don't split by
+        # sentence
         feature_positions = []
         feature_class = feature_code = ""
 
-        interest_words = ent.doc[ent.end-1 : ent.end + 1] # last word or next word following
+        interest_words = ent.doc[ent.end - 1 : ent.end + 1]  # last word or next word following
 
-        for word in interest_words: #ent.sent:
+        for word in interest_words:
             if ent.text in self._just_cts.keys():
                 feature_class = "A"
                 feature_code = "PCLI"
@@ -437,11 +443,10 @@ class Geoparser:
             elif word.text.lower() in A_other:
                 feature_class = "A"
                 feature_code = ""
-
         return (feature_class, feature_code)
 
 
-    def make_country_features(self, doc, require_maj = False):
+    def make_country_features(self, doc, require_maj=False):
         """
         Create features for the country picking model. Function where all the individual
         feature maker functions are called and aggregated. (Formerly "process_text")
@@ -474,16 +479,14 @@ class Geoparser:
         for ent in doc.ents:
             if not ent.text.strip():
                 continue
-            if ent.label_ not in ["GPE","LOC","FAC"]:
+            if ent.label_ not in ["GPE", "LOC", "FAC"]:
                 continue
             # don't include country names (make a parameter)
             if ent.text.strip() in self._skip_list:
                 continue
             ents.append(ent)
-
         if not ents:
             return []
-
         # Look them up in geonames, either sequentially if no threading, or
         # in parallel if threads.
         if self.threads:
@@ -492,10 +495,9 @@ class Geoparser:
             ent_results = pool.map(self.simple_lookup, ent_text)
             pool.close()
             pool.join()
-
         else:
-             ent_results = []
-             for ent in ents:
+            ent_results = []
+            for ent in ents:
                 try:
                     result = self.query_geonames(ent.text)
                 except ConnectionTimeout:
@@ -505,7 +507,7 @@ class Geoparser:
         for n, ent in enumerate(ents):
             result = ent_results[n]
             #skip_list.add(ent.text.strip())
-            ent_label = ent.label_ # destroyed by trimming
+            ent_label = ent.label_  # destroyed by trimming
             ent = self.clean_entity(ent)
 
             # vector for just the solo word
@@ -520,15 +522,9 @@ class Geoparser:
 
             # look for explicit mentions of feature names
             class_mention, code_mention = self._feature_location_type_mention(ent)
-
-            ##### ES-based features
-            #try:
-            #    result = self.query_geonames(ent.text)
-            #except ConnectionTimeout:
-            #    result = ""
-
             # build results-based features
             most_alt = self._feature_most_alternative(result)
+            # TODO check if most_common feature really isn't that useful
             most_common = self._feature_most_common(result)
             most_pop = self._feature_most_population(result)
             first_back, second_back = self._feature_first_back(result)
@@ -545,10 +541,8 @@ class Geoparser:
 
             if not maj_vote:
                 maj_vote = ""
-
             # We only want all this junk for the labeling task. We just want to straight to features
             # and the model when in production.
-
             try:
                 start = ent.start_char
                 end = ent.end_char
@@ -557,14 +551,13 @@ class Geoparser:
                     text_label = self._inv_cts[iso_label]
                 except KeyError:
                     text_label = ""
-
                 task = {"text" : ent.text,
-                        "label" : text_label, # human-readable country name
+                        "label" : text_label,  # human-readable country name
                         "word" : ent.text,
                         "spans" : [{
                             "start" : start,
                             "end" : end,
-                            } # make sure to rename for Prodigy
+                            }  # make sure to rename for Prodigy
                                 ],
                         "features" : {
                                 "maj_vote" : iso_label,
@@ -578,22 +571,23 @@ class Geoparser:
                                 "ct_mention2" : ct_mention2,
                                 "ctm_count2" : ctm_count2,
                                 "wv_confid" : wv_confid,
-                                "class_mention" : class_mention, # inferred geonames class from mentions
+                                "class_mention" : class_mention,  # inferred geonames class from mentions
                                 "code_mention" : code_mention,
                                 #"places_vec" : places_vec,
                                 #"doc_vec_sent" : doc_vec_sent
-                                } }
+                                }
+                        }
                 task_list.append(task)
             except Exception as e:
                 print(ent.text,)
                 print(e)
-        return task_list # rename this var
-
+        return task_list  # rename this var
     # Two modules that call `make_country_features`:
     #  1. write out with majority vote for training
     #  2. turn into features, run model, return countries
     #  A third, standalone function will convert the labeled JSON from Prodigy into
     #    features for updating the model.
+
 
     def make_country_matrix(self, loc):
         """
@@ -611,7 +605,7 @@ class Geoparser:
 
         top = loc['features']['ct_mention']
         top_count = loc['features']['ctm_count1']
-        two =  loc['features']['ct_mention2']
+        two = loc['features']['ct_mention2']
         two_count = loc['features']['ctm_count2']
         word_vec = loc['features']['word_vec']
         first_back = loc['features']['first_back']
@@ -624,7 +618,7 @@ class Geoparser:
         X_mat = []
 
         for label in possible_labels:
-            inputs  = np.array([word_vec, first_back, most_alt, most_pop])
+            inputs = np.array([word_vec, first_back, most_alt, most_pop])
             x = inputs == label
             x = np.asarray((x * 2) - 1) # convert to -1, 1
 
@@ -632,9 +626,9 @@ class Geoparser:
             exists = inputs != ""
             exists = np.asarray((exists * 2) - 1)
 
-            counts = np.asarray([top_count, two_count]) # cludgy, should be up with "inputs"
+            counts = np.asarray([top_count, two_count])  # cludgy, should be up with "inputs"
             right = np.asarray([top, two]) == label
-            right = right*2 - 1
+            right = right * 2 - 1
             right[counts == 0] = 0
 
             # get correct values
@@ -805,7 +799,7 @@ class Geoparser:
                 good_code_mention = 0
             ### edit distance
             ed = editdistance.eval(search_name, entry['name'])
-            ed = ed # shrug
+            ed = ed  # shrug
             # maybe also get min edit distance to alternative names...
 
             features = [has_pop, pop, logp, adj_rank, len_alt, adj_alt,
@@ -825,7 +819,7 @@ class Geoparser:
         """
         # total score is just a sum of each row
         total_score = X.sum(axis=1).transpose()
-        total_score = np.squeeze(np.asarray(total_score)) # matrix to array
+        total_score = np.squeeze(np.asarray(total_score))  # matrix to array
         ranks = total_score.argsort()
         ranks = ranks[::-1]
         # sort the list of dicts according to ranks
@@ -833,7 +827,7 @@ class Geoparser:
         sorted_X = X[ranks]
         return (sorted_X, sorted_meta)
 
-    def format_for_prodigy(self, X, meta, placename, return_feature_subset = False):
+    def format_for_prodigy(self, X, meta, placename, return_feature_subset=False):
         """
         Given a feature matrix, geonames data, and the original query,
         construct a prodigy task.
@@ -883,9 +877,9 @@ class Geoparser:
             return all_tasks
 
 
-
-    def format_geonames(self, entry, searchterm = None):
-        """Pull out just the fields we want from a geonames entry
+    def format_geonames(self, entry, searchterm=None):
+        """
+        Pull out just the fields we want from a geonames entry
 
         To do:
         - switch to model picking
@@ -928,8 +922,6 @@ class Geoparser:
                    "feature_code" : ""}
             return new_res
 
-
-
     def clean_proced(self, proced):
         """Small helper function to delete the features from the final dictionary.
         These features are mostly interesting for debugging but won't be relevant for most users.
@@ -965,7 +957,7 @@ class Geoparser:
                 pass
         return proced
 
-    def geoparse(self, doc, verbose = False):
+    def geoparse(self, doc, verbose=False):
         """Main geoparsing function. Text to extracted, resolved entities.
 
         Parameters
@@ -988,7 +980,6 @@ class Geoparser:
             return []
             # logging!
             #print("Nothing came back from infer_country...")
-
         if self.threads:
             pool = ThreadPool(len(proced))
             results = pool.map(self.proc_lookup_country, proced)
@@ -1025,11 +1016,10 @@ class Geoparser:
             place_confidence = prediction.max()
             loc['geo'] = sorted_meta[prediction.argmax()]
             loc['place_confidence'] = place_confidence
-
         if not verbose:
             proced = self.clean_proced(proced)
-
         return proced
+
 
     def batch_geoparse(self, text_list):
         """

--- a/mordecai/geoparse.py
+++ b/mordecai/geoparse.py
@@ -307,8 +307,8 @@ class Geoparser:
             q = {"multi_match": {"query": placename,
                                  "fields": ['name', 'asciiname', 'alternativenames'],
                                 "type" : "phrase"}}
-            r = Q("match", feature_code='PCLI')
-            res = self.conn.query(q).query(r)[0:5].execute()  # always 5
+            #r = Q("match", feature_code='PCLI')
+            res = self.conn.filter("term", feature_code='PCLI').query(q)[0:5].execute()  # always 5
             #self.country_exact = True
 
         else:
@@ -344,8 +344,8 @@ class Geoparser:
         q = {"multi_match": {"query": placename,
                              "fields": ['name^5', 'asciiname^5', 'alternativenames'],
                             "type" : "phrase"}}
-        r = Q("match", country_code3=country)
-        res = self.conn.query(q).query(r)[0:50].execute()
+        #r = Q("match", country_code3=country)
+        res = self.conn.filter("term", country_code3=country).query(q)[0:50].execute()
 
         # if no results, use some fuzziness, but still require all terms to be present.
         # Fuzzy is not allowed in "phrase" searches.
@@ -356,8 +356,9 @@ class Geoparser:
                                      "fuzziness" : 1,
                                      "operator":   "and"},
                 }
-            r = Q("match", country_code3=country)
-            res = self.conn.query(q).query(r)[0:50].execute()
+            #r = Q("match", country_code3=country)
+            #res = self.conn.query(q).query(r)[0:50].execute()
+            res = self.conn.filter("term", country_code3=country).query(q)[0:50].execute()
 
         out = utilities.structure_results(res)
         return out

--- a/mordecai/tests/conftest.py
+++ b/mordecai/tests/conftest.py
@@ -4,3 +4,7 @@ import pytest
 @pytest.fixture(scope='session', autouse=True)
 def geo():
     return Geoparser()
+
+@pytest.fixture(scope='session', autouse=True)
+def geo_thread():
+    return Geoparser(n_threads = 4)

--- a/mordecai/tests/conftest.py
+++ b/mordecai/tests/conftest.py
@@ -3,7 +3,7 @@ import pytest
 
 @pytest.fixture(scope='session', autouse=True)
 def geo():
-    return Geoparser()
+    return Geoparser(threads=False)
 
 @pytest.fixture(scope='session', autouse=True)
 def geo_thread():

--- a/mordecai/tests/conftest.py
+++ b/mordecai/tests/conftest.py
@@ -7,4 +7,4 @@ def geo():
 
 @pytest.fixture(scope='session', autouse=True)
 def geo_thread():
-    return Geoparser(n_threads = 4)
+    return Geoparser(threads=True)

--- a/mordecai/tests/test_mordecai.py
+++ b/mordecai/tests/test_mordecai.py
@@ -61,15 +61,41 @@ def test_make_country_features(geo):
     assert len(f[0]['spans']) == 1
     assert len(f[1]['spans']) == 1
 
+def test_make_country_features_thread(geo_thread):
+    doc = nlp("EULEX is based in Prishtina, Kosovo.")
+    f = geo_thread.make_country_features(doc)
+    assert f[0]['features']['most_alt'] == "XKX"
+    assert f[1]['features']['most_alt'] == "XKX"
+    assert f[0]['features']['word_vec'] == "XKX"
+    assert f[1]['features']['word_vec'] == "XKX"
+    assert f[0]['features']['wv_confid'] > 10
+    assert f[1]['features']['wv_confid'] > 10
+    assert len(f[0]['spans']) == 1
+    assert len(f[1]['spans']) == 1
+
+
 def test_infer_country1(geo):
     doc = "There's fighting in Aleppo and Homs."
     loc = geo.infer_country(doc)
     assert loc[0]['country_predicted'] == "SYR"
     assert loc[1]['country_predicted'] == "SYR"
 
+def test_infer_country1_thread(geo_thread):
+    doc = "There's fighting in Aleppo and Homs."
+    loc = geo_thread.infer_country(doc)
+    assert loc[0]['country_predicted'] == "SYR"
+    assert loc[1]['country_predicted'] == "SYR"
+
+
 def test_infer_country2(geo):
     doc = "There's fighting in Berlin and Hamburg."
     loc = geo.infer_country(doc)
+    assert loc[0]['country_predicted'] == "DEU"
+    assert loc[1]['country_predicted'] == "DEU"
+
+def test_infer_country2_thread(geo_thread):
+    doc = "There's fighting in Berlin and Hamburg."
+    loc = geo_thread.infer_country(doc)
     assert loc[0]['country_predicted'] == "DEU"
     assert loc[1]['country_predicted'] == "DEU"
 
@@ -118,7 +144,12 @@ def test_issue_40(geo):
     locs = geo.geoparse(doc)
     assert len(locs) > 2
 
-def test_issue_40(geo):
+def test_issue_40(geo_thread):
+    doc = "In early 1938, the Prime Minister cut grants-in-aid to the provinces, effectively killing the relief project scheme. Premier Thomas Dufferin Pattullo closed the projects in April, claiming that British Columbia could not shoulder the burden alone. Unemployed men again flocked to Vancouver to protest government insensitivity and intransigence to their plight. The RCPU organized demonstrations and tin-canning (organized begging) in the city. Under the guidance of twenty-six-year-old Steve Brodie, the leader of the Youth Division who had cut his activist teeth during the 1935 relief camp strike, protesters occupied Hotel Georgia, the Vancouver Art Gallery (then located at 1145 West Georgia Street), and the main post office (now the Sinclair Centre)."
+    locs = geo_thread.geoparse(doc)
+    assert len(locs) > 2
+
+def test_issue_40_2(geo):
     doc_list = ["Government forces attacked the cities in Aleppo Governorate, while rebel leaders met in Geneva.",
                 "EULEX is based in Prishtina, Kosovo.",
                 "Clientelism may depend on brokers."]
@@ -151,6 +182,29 @@ center of Region XI, it is 38 kilometres (24 mi) away within a 45-minute ride,
 while it is 16 kilometres (9.9 mi) or about 15-minute ride from provincial
 capital city of Digos."""
     locs = geo.geoparse(text)
+    assert len(locs) > 0
+
+def test_issue_45_thread(geo_thread):
+    text = """Santa Cruz is a first class municipality in
+the province of Davao del Sur, Philippines. It has a population of 81,093
+people as of 2010. The Municipality of Santa Cruz is part of Metropolitan
+Davao. Santa Cruz is politically subdivided into 18 barangays. Of the 18
+barangays, 7 are uplands, 9 are upland-lowland and coastal and 2 are
+lowland-coastal. Pista sa Kinaiyahan A yearly activity conducted every last
+week of April as a tribute to the Mother Nature through tree-growing, cleanup
+activities and Boulder Face challenge. Araw ng Santa Cruz It is celebrated
+every October 5 in commemoration of the legal creation of the municipality in
+1884. Highlights include parades, field demonstrations, trade fairs, carnivals
+and traditional festivities. Sinabbadan Festival A festival of ethnic ritual
+and dances celebrated every September. Santa Cruz is accessible by land
+transportation vehicles plying the Davao-Digos City, Davao-Kidapawan City,
+Davao-Cotabato City, Davao-Koronadal City and Davao-Tacurong City routes
+passing through the town's single, 27 kilometres (17 mi) stretch of national
+highway that traverses its 11 barangays. From Davao City, the administrative
+center of Region XI, it is 38 kilometres (24 mi) away within a 45-minute ride,
+while it is 16 kilometres (9.9 mi) or about 15-minute ride from provincial
+capital city of Digos."""
+    locs = geo_thread.geoparse(text)
     assert len(locs) > 0
 
 def test_ohio(geo):


### PR DESCRIPTION
Two major changes:

1. use threaded queries to query elasticsearch. The per-document speed is faster, but the overall process of geoparsing many documents is not. It's just more efficient, so it can be parallelized at a coarser lever. See #55. 
2. No longer attempt to split documents by sentence and don't try to calculate spans per sentence. The unit for every step is now the full document. (NB: Mordecai was trained on sentences, not large documents, so accuracy will probably be better with shorter documents). Not splitting into sentences saves a lot of time. Closes #53.

Minor changes:

- clean up imports
- fix some pep8 stuff