### PR TITLE
Optionally allow multiple hosts, SSL, and auth for connecting to ES

### DIFF
--- a/README.md
+++ b/README.md
@@ -118,11 +118,15 @@ API and Configuration
 
 When instantiating the `Geoparser()` module, the following options can be changed:
 
-- `es_ip` : Where the Geonames Elasticsearch service is running. Defaults to
-    `localhost`, which is where it runs if you're using the default Docker
-    setup described above.
+- `es_hosts` : List of hosts where the Geonames Elasticsearch service is
+    running. Defaults to `['localhost']`, which is where it runs if you're using
+    the default Docker setup described above.
 - `es_port` : What port the Geonames Elasticsearch service is running on.
     Defaults to `9200`, which is where the Docker setup has it
+- `es_ssl` : Whether Elasticsearch requires an SSL connection.
+    Defaults to `False`.
+- `es_auth` : Optional HTTP auth parameters to use with ES.
+    If provided, it should be a two-tuple of `(user, password)`.
 - `country_confidence` : Set the country model confidence below which no
     geolocation will be returned. If it's really low, the model's probably
     wrong and will return weird results. Defaults to `0.6`. 

--- a/mordecai/geoparse.py
+++ b/mordecai/geoparse.py
@@ -30,9 +30,9 @@ Install with this command: `python -m spacy download en_core_web_lg`.""")
 
 
 class Geoparser:
-    def __init__(self, es_ip="localhost", es_port="9200", verbose=False,
-                 country_threshold=0.6, threads=True, progress=True,
-                 mod_date="2018-06-05", **kwargs):
+    def __init__(self, es_hosts=None, es_port=None, es_ssl=False, es_auth=None,
+                 verbose=False, country_threshold=0.6, threads=True,
+                 progress=True, mod_date="2018-06-05", **kwargs):
         DATA_PATH = pkg_resources.resource_filename('mordecai', 'data/')
         MODELS_PATH = pkg_resources.resource_filename('mordecai', 'models/')
         self._cts = utilities.country_list_maker()
@@ -44,7 +44,7 @@ class Geoparser:
         self._prebuilt_vec = [w.vector for w in self._ct_nlp]
         self._both_codes = utilities.make_country_nationality_list(self._cts, DATA_PATH + "nat_df.csv")
         self._admin1_dict = utilities.read_in_admin1(DATA_PATH + "admin1CodesASCII.json")
-        self.conn = utilities.setup_es(es_ip, es_port)
+        self.conn = utilities.setup_es(es_hosts, es_port, es_ssl, es_auth)
         self.country_model = keras.models.load_model(MODELS_PATH + "country_model.h5")
         self.rank_model = keras.models.load_model(MODELS_PATH + "rank_model.h5")
         self._skip_list = utilities.make_skip_list(self._cts)

--- a/mordecai/geoparse.py
+++ b/mordecai/geoparse.py
@@ -67,7 +67,7 @@ class Geoparser:
 Are you sure it's running?
 Mordecai needs access to the Geonames/Elasticsearch gazetteer to function.
 See https://github.com/openeventdata/mordecai#installation-and-requirements
-for instructions on setting up Geonames/Elasticsearch""".format(es_ip, es_port))
+for instructions on setting up Geonames/Elasticsearch""".format(es_hosts, es_port))
         es_date = utilities.check_geonames_date(self.conn)
         if es_date != mod_date:
             print("""You may be using an outdated Geonames index.

--- a/mordecai/utilities.py
+++ b/mordecai/utilities.py
@@ -230,16 +230,20 @@ def structure_results(res):
         out['hits']['hits'].append(i_out)
     return out
 
-def setup_es(hosts, port, use_ssl, auth):
+def setup_es(hosts, port, use_ssl=False, auth=None):
     """
     Setup an Elasticsearch connection
 
     Parameters
     ----------
-    es_ip: string
-            IP address for elasticsearch instance
-    es_port: string
-            Port for elasticsearch instance
+    hosts: list
+            Hostnames / IP addresses for elasticsearch cluster
+    port: string
+            Port for elasticsearch cluster
+    use_ssl: boolean
+            Whether to use SSL for the elasticsearch connection
+    auth: tuple
+            (username, password) to use with HTTP auth
     Returns
     -------
     es_conn: an elasticsearch_dsl Search connection object.

--- a/mordecai/utilities.py
+++ b/mordecai/utilities.py
@@ -230,7 +230,7 @@ def structure_results(res):
         out['hits']['hits'].append(i_out)
     return out
 
-def setup_es(es_ip, es_port):
+def setup_es(hosts, port, use_ssl, auth):
     """
     Setup an Elasticsearch connection
 
@@ -244,7 +244,15 @@ def setup_es(es_ip, es_port):
     -------
     es_conn: an elasticsearch_dsl Search connection object.
     """
-    CLIENT = Elasticsearch([{'host' : es_ip, 'port' : es_port}])
+    kwargs = dict(
+        hosts=hosts or ['localhost'],
+        port=port or 9200,
+        use_ssl=use_ssl,
+    )
+    if auth:
+        kwargs.update(http_auth=auth)
+
+    CLIENT = Elasticsearch(**kwargs)
     S = Search(using=CLIENT, index="geonames")
     return S
 


### PR DESCRIPTION
This updates the code to allow for passing multiple hosts, HTTP auth, and setting SSL for the connection to ES. The defaults are unchanged.